### PR TITLE
Fix calling guess_mobileprovision script

### DIFF
--- a/isign/bin/isign_export_creds.sh
+++ b/isign/bin/isign_export_creds.sh
@@ -40,5 +40,5 @@ echo "Exported credentials from $p12_path to $target_dir"
 read -p "Find matching provisioning profile? [Y/n]:" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    ./guess_mobileprovision.sh $target_cert_path
+    bin/isign_guess_mobileprovision.sh $target_cert_path
 fi


### PR DESCRIPTION
- the export_creds only works if called from the upper directory of bin/, so that script should be run like this too